### PR TITLE
add env info / version to root

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,11 @@ if (config.env === 'development') {
   app.use('/graphiql', graphql.graphiql);
 }
 
+app.get('/', (req, res) => res.json({
+  env: config.env,
+  version: config.version
+});
+
 cron(app);
 
 app.listen(config.port);

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ if (config.env === 'development') {
 app.get('/', (req, res) => res.json({
   env: config.env,
   version: config.version
-});
+}));
 
 cron(app);
 


### PR DESCRIPTION
this makes heroku not vomit when checking the root