### PR TITLE
fix template rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "body-parser": "^1.15.2",
     "cors": "^2.7.1",
     "cron": "^1.1.0",
-    "daily-templates": "^0.6.0",
+    "daily-templates": "^0.6.1",
     "express": "^4.14.0",
     "express-sslify": "^1.1.0",
     "graphql": "^0.7.2",

--- a/src/models/edition.js
+++ b/src/models/edition.js
@@ -7,7 +7,7 @@ const blurbModel = require('./blurb');
 const blurbToComponent = (type, data) => {
   const templateName = Object.keys(templates).find(tpl => tpl.toLowerCase() === type);
   const Template = templates[templateName];
-  return (Template) ? React.createElement(Template, data) : '';
+  return (Template) ? React.createElement(Template, { data }) : '';
 };
 
 const formatEditionData = (editionData) => ({


### PR DESCRIPTION
the data property of a template now accepts `data` as an argument so it
must be nested, not the root